### PR TITLE
ReduxAdvanced: float downsampling_factor for better control

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -202,7 +202,7 @@ class ReduxAdvanced:
                              "style_model": ("STYLE_MODEL", ),
                              "clip_vision": ("CLIP_VISION", ),
                              "image": ("IMAGE",),
-                             "downsampling_factor": ("INT", {"default": 3, "min": 1, "max":9}),
+                             "downsampling_factor": ("FLOAT", {"default": 3.0, "min": 1.0, "max": 9.0}),
                              "downsampling_function": (["nearest", "bilinear", "bicubic","area","nearest-exact"], {"default": "area"}),
                              "mode": (IMAGE_MODES, {"default": "center crop (square)"}),
                              "weight": ("FLOAT", {"default": 1.0, "min":0.0, "max":1.0, "step":0.01})
@@ -227,9 +227,10 @@ class ReduxAdvanced:
             cond = cond.view(b, m, m, h)
             if mask is not None:
                 cond = cond*mask
-            cond=torch.nn.functional.interpolate(cond.transpose(1,-1), size=(m//downsampling_factor, m//downsampling_factor), mode=downsampling_function)
+            downsampled_size = (round(m/downsampling_factor), round(m/downsampling_factor))
+            cond=torch.nn.functional.interpolate(cond.transpose(1,-1), size=downsampled_size, mode=downsampling_function)
             cond=cond.transpose(1,-1).reshape(b,-1,h)
-            mask = None if mask is None else torch.nn.functional.interpolate(mask.view(b, m, m, 1).transpose(1,-1), size=(m//downsampling_factor, m//downsampling_factor), mode=mode).transpose(-1,1)
+            mask = None if mask is None else torch.nn.functional.interpolate(mask.view(b, m, m, 1).transpose(1,-1), size=downsampled_size, mode=mode).transpose(-1,1)
         cond = cond*(weight*weight)
         c = []
         if mask is not None:


### PR DESCRIPTION
This change makes `downsampling_factor` FLOAT instead of INTEGER, so it's more flexible. I don't see any downside to making it float.

Tested it works.

Here is an example when I mix two images and with float I can control the strengh of each image with better precision. 
<img width="307" alt="Screenshot 2025-01-17 at 9 53 41 AM" src="https://github.com/user-attachments/assets/a2b5c092-92a9-4385-b9d2-3f2a48d79468" />
<img width="298" alt="Screenshot 2025-01-17 at 9 52 34 AM" src="https://github.com/user-attachments/assets/12e0ac1b-2ce0-4f07-bc0c-b17307f8f9d1" />
<img width="299" alt="Screenshot 2025-01-17 at 9 52 10 AM" src="https://github.com/user-attachments/assets/6cc4a5ed-333f-48d0-8872-d841fa5539d3" />
