### PR TITLE
bugfix: reshape mask to (B, H, W)

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -244,7 +244,7 @@ class ReduxAdvanced:
         for t in conditioning:
             n = [torch.cat((t[0], cond), dim=1), t[1].copy()]
             c.append(n)
-        return (c, image, masko)
+        return (c, image, masko.squeeze(-1))
 
 
 # A dictionary that contains all nodes you want to export with their names


### PR DESCRIPTION
The mask output of ReduxAdvanced node has shape (B, H, W, 1)，which is not the valid shape as input to PreviewMask node.

See code: https://github.com/cubiq/ComfyUI_essentials/blob/main/mask.py#L99

So, we should reshape mask to (B, H, W) to avoid generating invalid temp output images in PreviewMask.