### PR TITLE
Fix: Ensure Consistent MASK Output Dimensions from ReduxAdvanced Node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -94,7 +94,7 @@ def letterbox(img, mask, w, h, desiredSize):
         mask=torch.nn.functional.interpolate(mask, size=(h,w), mode="bicubic")
         letterbox = torch.zeros(size=(b,1,desiredSize,desiredSize))
         letterbox[:, :, offsety:(offsety+h), offsetx:(offsetx+w)] += mask
-        mask = letterbox.view(b,1,desiredSize,desiredSize)
+        mask = letterbox.movedim(1, -1) # B C H W -> B H W C
     return (img, mask)
 
 def getBoundingBox(mask, w, h, relativeMargin, desiredSize):


### PR DESCRIPTION
**Description:**

This PR addresses an inconsistency in the dimensions of the MASK tensor returned by the `ReduxAdvanced` node.

**Problem:**

Previously, the shape of the returned `masko` tensor depended on the `mode` setting, specifically on whether the internal `prepareImageAndMask` function utilized the `crop` or `letterbox` helper function:

1.  **`crop` path (`mode="center crop (square)"`):** This path (after recent user edits) produced a mask with shape `(batch, height, width, 1)`.
2.  **`letterbox` path (`mode="keep aspect ratio"` or `"autocrop with mask"`):** This path produced a mask with shape `(batch, 1, height, width)`.

The final `return` statement in `apply_stylemodel` used `masko.squeeze(-1)`. This correctly processed the `(b, h, w, 1)` output from `crop` into the standard `(b, h, w)` mask format. However, it did **not** correctly process the `(b, 1, h, w)` output from `letterbox`, leaving it as a 4D tensor (unless width happened to be 1).

This inconsistency meant that the MASK output type did not have a stable dimension format, potentially causing issues with downstream nodes that expect the standard ComfyUI 3D mask format `(batch, height, width)`, such as `Conditioning (Set Mask)` or `GrowMask`. While the `MaskToImage` node could handle both formats, this masked the underlying inconsistency in the `ReduxAdvanced` node's output.

**Solution:**

The core change is minimal and focuses on unifying the output format _before_ the final `squeeze`.

1.  **Modified `letterbox` function:** The final step in handling the mask within `letterbox` was changed from `.view(b, 1, desiredSize, desiredSize)` (which was effectively a no-op) to `.movedim(1, -1)`. This moves the channel dimension (dim 1) to the end, transforming the shape from `(b, 1, h, w)` to `(b, h, w, 1)`.
2.  **Consistent Output:** With this change, both `crop` and `letterbox` now return masks with the shape `(b, h, w, 1)` (when a mask is present).
3.  **Effective Squeeze:** Consequently, the existing `masko.squeeze(-1)` in the `apply_stylemodel`'s return statement now correctly handles the output from **both** paths, reliably producing the standard 3D mask format `(batch, height, width)`.

**Benefit:**

This change guarantees that the `ReduxAdvanced` node's MASK output is always a standard 3D tensor `(batch, height, width)`, improving compatibility and predictability when connecting to other ComfyUI nodes.
